### PR TITLE
Remove duplicated Gordon

### DIFF
--- a/_posts/2022-06-28-benton22a.md
+++ b/_posts/2022-06-28-benton22a.md
@@ -26,13 +26,13 @@ lastpage: 1816
 page: 1798-1816
 order: 1798
 cycles: false
-bibtex_author: Benton, Gregory and Maddox, Wesley and Wilson, Andrew Gordon Gordon
+bibtex_author: Benton, Gregory and Maddox, Wesley and Wilson, Andrew Gordon
 author:
 - given: Gregory
   family: Benton
 - given: Wesley
   family: Maddox
-- given: Andrew Gordon Gordon
+- given: Andrew Gordon
   family: Wilson
 date: 2022-06-28
 address:

--- a/_posts/2022-06-28-lotfi22a.md
+++ b/_posts/2022-06-28-lotfi22a.md
@@ -29,7 +29,7 @@ page: 14223-14247
 order: 14223
 cycles: false
 bibtex_author: Lotfi, Sanae and Izmailov, Pavel and Benton, Gregory and Goldblum,
-  Micah and Wilson, Andrew Gordon Gordon
+  Micah and Wilson, Andrew Gordon
 author:
 - given: Sanae
   family: Lotfi
@@ -39,7 +39,7 @@ author:
   family: Benton
 - given: Micah
   family: Goldblum
-- given: Andrew Gordon Gordon
+- given: Andrew Gordon
   family: Wilson
 date: 2022-06-28
 address:

--- a/_posts/2022-06-28-stanton22a.md
+++ b/_posts/2022-06-28-stanton22a.md
@@ -29,7 +29,7 @@ page: 20459-20478
 order: 20459
 cycles: false
 bibtex_author: Stanton, Samuel and Maddox, Wesley and Gruver, Nate and Maffettone,
-  Phillip and Delaney, Emily and Greenside, Peyton and Wilson, Andrew Gordon Gordon
+  Phillip and Delaney, Emily and Greenside, Peyton and Wilson, Andrew Gordon
 author:
 - given: Samuel
   family: Stanton
@@ -43,7 +43,7 @@ author:
   family: Delaney
 - given: Peyton
   family: Greenside
-- given: Andrew Gordon Gordon
+- given: Andrew Gordon
   family: Wilson
 date: 2022-06-28
 address:

--- a/_posts/2022-06-28-zhang22ag.md
+++ b/_posts/2022-06-28-zhang22ag.md
@@ -26,11 +26,11 @@ lastpage: 26644
 page: 26624-26644
 order: 26624
 cycles: false
-bibtex_author: Zhang, Ruqi and Wilson, Andrew Gordon Gordon and De Sa, Christopher
+bibtex_author: Zhang, Ruqi and Wilson, Andrew Gordon and De Sa, Christopher
 author:
 - given: Ruqi
   family: Zhang
-- given: Andrew Gordon Gordon
+- given: Andrew Gordon
   family: Wilson
 - given: Christopher
   family: De Sa


### PR DESCRIPTION
By chance, I found "Andrew Gordon Wilson" name contains an additional "Gordon". So this PR removes them.